### PR TITLE
feat: 클라이언트 빌드 결과물 바이너리 임베딩

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,10 @@ uuid = { version = "1", features = ["v4"] }
 parking_lot = "0.12"
 http = "1"
 
+# Static file embedding
+rust-embed = { version = "8.11", features = ["axum"] }
+mime_guess = "2.0"
+
 [workspace.lints.rust]
 unsafe_code = "warn"
 

--- a/crates/marble-server/Cargo.toml
+++ b/crates/marble-server/Cargo.toml
@@ -28,3 +28,5 @@ anyhow.workspace = true
 uuid.workspace = true
 parking_lot.workspace = true
 http.workspace = true
+rust-embed.workspace = true
+mime_guess.workspace = true

--- a/crates/marble-server/build.rs
+++ b/crates/marble-server/build.rs
@@ -1,0 +1,34 @@
+//! Build script for marble-server
+//!
+//! Validates that the dist/ folder exists for rust-embed.
+//! The actual client build should be done separately via `trunk build`
+//! before building the server.
+//!
+//! Use `just build-server` to build both client and server in the correct order.
+
+use std::env;
+use std::path::Path;
+
+fn main() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let workspace_root = Path::new(&manifest_dir).join("../..");
+    let dist_dir = workspace_root.join("dist");
+
+    // Rerun if dist/ directory changes
+    println!("cargo:rerun-if-changed={}", dist_dir.display());
+
+    // Check if dist/ directory exists
+    if !dist_dir.exists() {
+        // SKIP_CLIENT_BUILD allows building without dist/ (for CI or dev)
+        if env::var("SKIP_CLIENT_BUILD").is_ok() {
+            println!("cargo:warning=SKIP_CLIENT_BUILD set, dist/ directory missing but continuing");
+            // Create empty dist with placeholder for rust-embed
+            std::fs::create_dir_all(&dist_dir).ok();
+            std::fs::write(dist_dir.join("index.html"), "<!-- placeholder -->").ok();
+        } else {
+            println!("cargo:warning=dist/ directory not found!");
+            println!("cargo:warning=Run `trunk build --release` first, or use `just build-server`");
+            println!("cargo:warning=Set SKIP_CLIENT_BUILD=1 to skip this check");
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -29,6 +29,15 @@ build-release:
     cargo build --release --all
     trunk build --release
 
+# Build server with embedded client (single binary deployment)
+build-server:
+    trunk build --release
+    cargo build -p marble-server --release
+
+# Build server (skip client build, assumes dist/ exists)
+build-server-only:
+    SKIP_CLIENT_BUILD=1 cargo build -p marble-server --release
+
 # Run all tests
 test:
     cargo test --all


### PR DESCRIPTION
## Summary
- rust-embed를 사용하여 marble-client의 dist/ 폴더를 marble-server 바이너리에 임베딩
- 단일 실행 파일로 배포 가능 (런타임 파일시스템 접근 불필요)
- `just build-server` 명령으로 클라이언트 + 서버 순차 빌드
- `SKIP_CLIENT_BUILD=1` 환경변수로 클라이언트 빌드 스킵 가능

## Changes
| 파일 | 변경 내용 |
|------|----------|
| `Cargo.toml` | rust-embed 8.11, mime_guess 2.0 워크스페이스 의존성 추가 |
| `crates/marble-server/Cargo.toml` | rust-embed, mime_guess 의존성 추가 |
| `crates/marble-server/build.rs` | dist/ 폴더 존재 여부 검증 (신규) |
| `crates/marble-server/src/main.rs` | ServeDir → rust-embed 기반 정적 파일 서빙 |
| `justfile` | `build-server`, `build-server-only` 명령 추가 |

## Test plan
- [ ] `just build-server` 실행하여 단일 바이너리 빌드 확인
- [ ] 빌드된 바이너리 실행 후 http://localhost:3000 접속하여 SPA 로딩 확인
- [ ] gRPC-Web, WebSocket signaling 정상 동작 확인

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)